### PR TITLE
Fix markdown in README.md of serverless-localstack directory

### DIFF
--- a/examples/serverless-localstack/README.md
+++ b/examples/serverless-localstack/README.md
@@ -38,12 +38,11 @@ ddt -i
 ```
 
 #### Standalone npm package usage:
-init - `ddt init -tableNames "Users"`
-up - `ddt up`
-down - `ddt down -t Users`
-prepare - `ddt prepare -t Users --tNumber 3`
-history - `ddt history -t Users`
-```
+- init - `ddt init -tableNames "Users"`
+- up - `ddt up`
+- down - `ddt down -t Users`
+- prepare - `ddt prepare -t Users --tNumber 3`
+- history - `ddt history -t Users`
 
 
 


### PR DESCRIPTION
Fix two markdown formatting issues in README.md of `serverless-localstack` directory:
1. Under [Standalone npm package usage](https://github.com/jitsecurity/dynamo-data-transform/tree/main/examples/serverless-localstack#standalone-npm-package-usage), all items were listed in the same row.
2. The entire `Exercises` section was mistakenly formatted as code because of the unnecessary 3 backticks at the end of the previous section.