### PR TITLE
feat: allow to selectively update items

### DIFF
--- a/src/utils/transformItems.js
+++ b/src/utils/transformItems.js
@@ -11,7 +11,7 @@ const transformItems = async (ddb, tableName, transformer, isDryRun) => {
     const { Items, LastEvaluatedKey } = await getItems(ddb, lastEvalKey, tableName);
     lastEvalKey = LastEvaluatedKey;
 
-    const updatedItems = Items.map(transformer);
+    const updatedItems = Items.map(transformer).filter(i => i !== undefined);
 
     if (!isDryRun && updatedItems.length > 0) {
       if (updatedItems?.length) await batchWriteItems(ddb, tableName, updatedItems);


### PR DESCRIPTION
The DynamoDB paradigm is to have a single database per service.
This mean that a table can contain different kind of entities and often, you don't want to update all the entities.

This PR make it possible to selectively transform entries, e.g:

```ts
  const addNewFieldsToUser = (item) => {
    if (item.pk.startsWith("user#")) {
      const updatedItem = {
        ...item,
        surname: "Tom"
      };
      return updatedItem;
    }
    return undefined;

  };
```